### PR TITLE
Upgrade to gradle wrapper 7.5, restructure tests and imlementation of cache.getIfPresent and cache.put

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,5 @@
 plugins {
     id 'java'
-    id 'jacoco'
     id 'maven-publish'
     id 'com.enonic.xp.base' version '3.2.0'
     id 'com.enonic.defaults' version '2.1.2'
@@ -12,20 +11,23 @@ repositories {
 }
 
 dependencies {
-    compile "com.enonic.xp:script-api:${xpVersion}"
-    testCompile 'junit:junit:4.13.2'
-    testCompile "com.enonic.xp:testing:${xpVersion}"
+    compileOnly "com.enonic.xp:script-api:${xpVersion}"
+    testImplementation "com.enonic.xp:testing:${xpVersion}"
+    testImplementation 'org.mockito:mockito-junit-jupiter:5.1.1'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.9.2'
 }
 
-jacocoTestReport {
-    reports {
-        xml.enabled = true
-        html.enabled = true
+publishing {
+    publications {
+        maven(MavenPublication) {
+            groupId = "${group}"
+            artifactId = "${projectName}"
+            version = "${version}"
+            from components.java
+        }
     }
 }
 
-check.dependsOn jacocoTestReport
-
-artifacts {
-    archives jar
+test {
+    useJUnitPlatform()
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'java'
+    id 'jacoco'
     id 'maven-publish'
     id 'com.enonic.xp.base' version '3.2.0'
     id 'com.enonic.defaults' version '2.1.2'
@@ -17,15 +18,17 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter:5.9.2'
 }
 
-publishing {
-    publications {
-        maven(MavenPublication) {
-            groupId = "${group}"
-            artifactId = "${projectName}"
-            version = "${version}"
-            from components.java
-        }
+jacocoTestReport {
+    reports {
+        xml.required = true
+        html.required = true
     }
+}
+
+check.dependsOn jacocoTestReport
+
+artifacts {
+    archives jar
 }
 
 test {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 group=com.enonic.lib
 projectName=lib-cache
 xpVersion=7.0.0
-version=2.2.0-SNAPSHOT
+version=2.3.0-SNAPSHOT

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.9.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/com/enonic/lib/cache/CacheBean.java
+++ b/src/main/java/com/enonic/lib/cache/CacheBean.java
@@ -21,6 +21,18 @@ public final class CacheBean
         return this.cache.get( key, callback );
     }
 
+    public Object getIfPresent( final String key )
+        throws Exception
+    {
+        return this.cache.getIfPresent( key );
+    }
+
+    public void put(final String key, final Object value)
+        throws Exception
+    {
+        this.cache.put( key, value );
+    }
+
     public void clear()
     {
         this.cache.invalidateAll();

--- a/src/main/resources/lib/cache.js
+++ b/src/main/resources/lib/cache.js
@@ -31,6 +31,27 @@ Cache.prototype.get = function (key, callback) {
 };
 
 /**
+ * Returns value for cache entry if exists, otherwise it returns null.
+ *
+ * @param {string} key Cache key to use.
+ * @returns {*} Cache value for key.
+ */
+Cache.prototype.getIfPresent = function (key) {
+    var result = this.cache.getIfPresent(key);
+    return __.toNativeObject(result);
+};
+
+/**
+ * Puts the value into the cache with the provided key
+ * 
+ * @param {string} key Cache key to use.
+ * @param {Object} value Value to store in the cache.
+ */
+Cache.prototype.put = function (key, value){
+    this.cache.put(key, value);
+}
+
+/**
  * Clears the cache.
  */
 Cache.prototype.clear = function () {

--- a/src/test/java/com/enonic/lib/cache/CacheBeanBuilderTest.java
+++ b/src/test/java/com/enonic/lib/cache/CacheBeanBuilderTest.java
@@ -21,5 +21,9 @@ public class CacheBeanBuilderTest
 
         bean.clear();
         assertEquals( 0, bean.getSize() );
+
+        bean.put( "key2", "value2" );
+        final Object value2 = bean.get( "key2", () -> "notValue2" );
+        assertEquals( "value2", value2);
     }
 }

--- a/src/test/java/com/enonic/lib/cache/CacheScriptTest.java
+++ b/src/test/java/com/enonic/lib/cache/CacheScriptTest.java
@@ -1,4 +1,6 @@
 package com.enonic.lib.cache;
+import java.beans.Transient;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -23,6 +25,18 @@ public class CacheScriptTest
     public void testCache()
     {
         runFunction( "/test/cache-test.js", "testCache" );
+    }
+
+    @Test
+    public void testGetIfPresent()
+    {
+        runFunction( "/test/cache-test.js", "testGetIfPresent" );
+    }
+
+    @Test
+    public void testPut()
+    {
+        runFunction( "/test/cache-test.js", "testPut");
     }
 
     @Test

--- a/src/test/java/com/enonic/lib/cache/CacheScriptTest.java
+++ b/src/test/java/com/enonic/lib/cache/CacheScriptTest.java
@@ -1,13 +1,39 @@
 package com.enonic.lib.cache;
-
-import com.enonic.xp.testing.ScriptRunnerSupport;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import com.enonic.xp.security.SecurityService;
+import com.enonic.xp.testing.ScriptTestSupport;
 
 public class CacheScriptTest
-    extends ScriptRunnerSupport
+    extends ScriptTestSupport
 {
-    @Override
-    public String getScriptTestFile()
+    private SecurityService securityService;
+
+    @BeforeEach
+    public void initialize()
+        throws Exception
     {
-        return "/test/cache-test.js";
+        super.initialize();
+        this.securityService = Mockito.mock( SecurityService.class );
+        addService( SecurityService.class, this.securityService );
+    }
+
+    @Test
+    public void testCache()
+    {
+        runFunction( "/test/cache-test.js", "testCache" );
+    }
+
+    @Test
+    public void testRemove()
+    {
+        runFunction( "/test/cache-test.js", "testRemove" );
+    }
+    
+    @Test
+    public void testRemovePattern()
+    {
+        runFunction( "/test/cache-test.js", "testRemovePattern" );
     }
 }

--- a/src/test/resources/test/cache-test.js
+++ b/src/test/resources/test/cache-test.js
@@ -1,4 +1,4 @@
-var t = require('/lib/xp/testing.js');
+var assert = require('/lib/xp/testing');
 var cacheLib = require('/lib/cache');
 
 exports.testCache = function () {
@@ -8,7 +8,7 @@ exports.testCache = function () {
         expire: 10
     });
 
-    t.assertEquals(0, cache.getSize());
+    assert.assertEquals(0, cache.getSize());
 
     var numCalled = 0;
     var calcFunction = function () {
@@ -21,24 +21,48 @@ exports.testCache = function () {
     };
 
     var result = cache.get('key1', calcFunction);
-    t.assertEquals(1, result.num);
-    t.assertEquals('value1', result.name);
-    t.assertEquals(1, cache.getSize());
+    assert.assertEquals(1, result.num);
+    assert.assertEquals('value1', result.name);
+    assert.assertEquals(1, cache.getSize());
 
     result = cache.get('key1', calcFunction);
-    t.assertEquals(1, result.num);
-    t.assertEquals('value1', result.name);
-    t.assertEquals(1, cache.getSize());
+    assert.assertEquals(1, result.num);
+    assert.assertEquals('value1', result.name);
+    assert.assertEquals(1, cache.getSize());
 
     result = cache.get('key2', calcFunction);
-    t.assertEquals(2, result.num);
-    t.assertEquals('value2', result.name);
-    t.assertEquals(2, cache.getSize());
+    assert.assertEquals(2, result.num);
+    assert.assertEquals('value2', result.name);
+    assert.assertEquals(2, cache.getSize());
 
     cache.clear();
-    t.assertEquals(0, cache.getSize());
+    assert.assertEquals(0, cache.getSize());
 
 };
+
+exports.testGetIfPresent = function(){
+    var cache = cacheLib.newCache({
+        size: 100,
+        expire: 10
+    });
+    assert.assertEquals(null, cache.getIfPresent('key1'));
+};
+
+exports.testPut = function(){
+
+    var cache = cacheLib.newCache({
+        size: 100,
+        expire: 10
+    });
+
+    cache.put('key1', 5);
+
+    var getKey1 = cache.get('key1', function(){
+        return 4;
+    });
+
+    assert.assertEquals(5, getKey1);
+}
 
 exports.testRemove = function () {
 
@@ -47,7 +71,7 @@ exports.testRemove = function () {
         expire: 10
     });
 
-    t.assertEquals(0, cache.getSize());
+    assert.assertEquals(0, cache.getSize());
 
     var numCalled = 0;
     var calcFunction = function () {
@@ -60,12 +84,12 @@ exports.testRemove = function () {
     };
 
     var result = cache.get('key1', calcFunction);
-    t.assertEquals(1, result.num);
-    t.assertEquals('value1', result.name);
-    t.assertEquals(1, cache.getSize());
+    assert.assertEquals(1, result.num);
+    assert.assertEquals('value1', result.name);
+    assert.assertEquals(1, cache.getSize());
 
     cache.remove('key1');
-    t.assertEquals(0, cache.getSize());
+    assert.assertEquals(0, cache.getSize());
 };
 
 exports.testRemovePattern = function () {
@@ -75,7 +99,7 @@ exports.testRemovePattern = function () {
         expire: 10
     });
 
-    t.assertEquals(0, cache.getSize());
+    assert.assertEquals(0, cache.getSize());
 
     var numCalled = 0;
     var calcFunction = function () {
@@ -93,8 +117,8 @@ exports.testRemovePattern = function () {
     cache.get('k1', calcFunction);
     cache.get('k2', calcFunction);
 
-    t.assertEquals(5, cache.getSize());
+    assert.assertEquals(5, cache.getSize());
 
     cache.removePattern('key.*');
-    t.assertEquals(2, cache.getSize());
+    assert.assertEquals(2, cache.getSize());
 };

--- a/src/test/resources/test/cache-test.js
+++ b/src/test/resources/test/cache-test.js
@@ -1,4 +1,4 @@
-var assert = require('/lib/xp/testing');
+var t = require('/lib/xp/testing.js');
 var cacheLib = require('/lib/cache');
 
 exports.testCache = function () {
@@ -8,7 +8,7 @@ exports.testCache = function () {
         expire: 10
     });
 
-    assert.assertEquals(0, cache.getSize());
+    t.assertEquals(0, cache.getSize());
 
     var numCalled = 0;
     var calcFunction = function () {
@@ -21,22 +21,22 @@ exports.testCache = function () {
     };
 
     var result = cache.get('key1', calcFunction);
-    assert.assertEquals(1, result.num);
-    assert.assertEquals('value1', result.name);
-    assert.assertEquals(1, cache.getSize());
+    t.assertEquals(1, result.num);
+    t.assertEquals('value1', result.name);
+    t.assertEquals(1, cache.getSize());
 
     result = cache.get('key1', calcFunction);
-    assert.assertEquals(1, result.num);
-    assert.assertEquals('value1', result.name);
-    assert.assertEquals(1, cache.getSize());
+    t.assertEquals(1, result.num);
+    t.assertEquals('value1', result.name);
+    t.assertEquals(1, cache.getSize());
 
     result = cache.get('key2', calcFunction);
-    assert.assertEquals(2, result.num);
-    assert.assertEquals('value2', result.name);
-    assert.assertEquals(2, cache.getSize());
+    t.assertEquals(2, result.num);
+    t.assertEquals('value2', result.name);
+    t.assertEquals(2, cache.getSize());
 
     cache.clear();
-    assert.assertEquals(0, cache.getSize());
+    t.assertEquals(0, cache.getSize());
 
 };
 
@@ -47,7 +47,7 @@ exports.testRemove = function () {
         expire: 10
     });
 
-    assert.assertEquals(0, cache.getSize());
+    t.assertEquals(0, cache.getSize());
 
     var numCalled = 0;
     var calcFunction = function () {
@@ -60,12 +60,12 @@ exports.testRemove = function () {
     };
 
     var result = cache.get('key1', calcFunction);
-    assert.assertEquals(1, result.num);
-    assert.assertEquals('value1', result.name);
-    assert.assertEquals(1, cache.getSize());
+    t.assertEquals(1, result.num);
+    t.assertEquals('value1', result.name);
+    t.assertEquals(1, cache.getSize());
 
     cache.remove('key1');
-    assert.assertEquals(0, cache.getSize());
+    t.assertEquals(0, cache.getSize());
 };
 
 exports.testRemovePattern = function () {
@@ -75,7 +75,7 @@ exports.testRemovePattern = function () {
         expire: 10
     });
 
-    assert.assertEquals(0, cache.getSize());
+    t.assertEquals(0, cache.getSize());
 
     var numCalled = 0;
     var calcFunction = function () {
@@ -93,8 +93,8 @@ exports.testRemovePattern = function () {
     cache.get('k1', calcFunction);
     cache.get('k2', calcFunction);
 
-    assert.assertEquals(5, cache.getSize());
+    t.assertEquals(5, cache.getSize());
 
     cache.removePattern('key.*');
-    assert.assertEquals(2, cache.getSize());
+    t.assertEquals(2, cache.getSize());
 };


### PR DESCRIPTION
Im working on a project where lib-cache is a key component.
I have a need for the com.google.common.cache.Cache put and getIfPresent functions, and implemented those.
I also upgraded gradle wrapper to 7.5. Could be usefull for others, hence the pull request.
The tests from the previous release was giving mockito warnings in gradle 7.5, so I looked at lib-cron to see how a newly updated lib handled those, and changed lib-cache to test in the same way.