### PR TITLE
Add release-branch CI config for 2.x

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -13,6 +13,9 @@ jobs:
         with:
           repoUser: ci
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            2.x
 
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Adds the `releaseBranch:` block to `enonic-gradle.yml` so both `master` (XP 8 / 3.x line) and `2.x` (XP 7 maintenance line) trigger releases through `enonic/release-tools/build-and-publish`.

## Why
- This branch (`2.x`) was created from `master` HEAD just before the XP 8 upgrade landed and now serves as the XP 7.13.0 maintenance line. The workflow needs to recognise it as a release branch so bugfix versions can be published from here without falling back to snapshots.

## Notes
- `gradle.properties` is intentionally untouched: `2.x` keeps `xpVersion=7.13.0` / `version=2.2.2-SNAPSHOT`. The XP 8 upgrade and version bump go on `master` in a separate PR.
- `enonic-docgen.yml` and `docs/versions.json` are master-only per the app-booster maintenance pattern; this PR does not touch them.

## Test plan
- [ ] CI workflow on this branch (`chore/2.x-add-release-branch`) parses the new YAML successfully.
- [ ] After merge, a push to `2.x` continues to build and the workflow recognises it as a release branch.