### PR TITLE
Add @enonic-types/lib-cache types package #118

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -2,6 +2,10 @@ name: Gradle Build
 
 on: [ push ]
 
+permissions:
+  id-token: write  # Required for npm OIDC / trusted publishing
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -13,6 +17,7 @@ jobs:
         with:
           repoUser: ci
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          npmPublish: true
           releaseBranch: |
             master
             2.x

--- a/build.gradle
+++ b/build.gradle
@@ -41,3 +41,15 @@ artifacts {
 test {
     useJUnitPlatform()
 }
+
+// Assemble the @enonic-types/lib-cache npm package (published on release by the CI npmPublish step).
+tasks.register('assembleTypes', Copy) {
+    from 'types'
+    into layout.buildDirectory.dir('types')
+    filesMatching('package.json') {
+        filter { line ->
+            line.replaceAll(/"version":\s*"[^"]*"/, "\"version\": \"${project.version}\"")
+        }
+    }
+}
+jar.dependsOn assembleTypes

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,81 @@
+declare module "/lib/cache" {
+    export interface CacheOptions {
+        /**
+         * Maximum number of elements in the cache. If not set, the cache is unbounded.
+         */
+        size?: number;
+
+        /**
+         * Expire time (in seconds) for cache entries. If not set, entries never expire.
+         */
+        expire?: number;
+    }
+
+    export interface Cache {
+        /**
+         * Returns value for cache entry if it exists; otherwise the callback is invoked, its result is stored and returned.
+         *
+         * @param key Cache key to use.
+         * @param callback Function that computes the value if the key is not present in the cache.
+         * @returns Cache value for key.
+         */
+        get<A>(key: string, callback: () => A): A;
+
+        /**
+         * Returns value for cache entry if it exists; otherwise returns null.
+         *
+         * @param key Cache key to use.
+         * @returns Cache value for key, or null if not present.
+         */
+        getIfPresent<A>(key: string): A | null;
+
+        /**
+         * Puts the value into the cache with the provided key.
+         *
+         * Objects are cached by reference: modifying an object after storing it, or modifying an object retrieved from
+         * the cache, could affect the cached value. Deep clone after retrieval if the value must be changed.
+         *
+         * @param key Cache key to use.
+         * @param value Value to store in the cache.
+         */
+        put(key: string, value: unknown): void;
+
+        /**
+         * Clears the cache.
+         */
+        clear(): void;
+
+        /**
+         * Returns the number of elements currently in the cache.
+         */
+        getSize(): number;
+
+        /**
+         * Removes an entry, identified by its key, from the cache.
+         *
+         * If the key is not found in the cache, no changes are made.
+         *
+         * @param key Cache key to remove.
+         */
+        remove(key: string): void;
+
+        /**
+         * Removes multiple entries, identified by a regular expression, from the cache.
+         *
+         * If the regex pattern does not match any existing key, no changes are made.
+         *
+         * @param keyRegex Regular expression pattern to match with keys to be removed.
+         */
+        removePattern(keyRegex: string): void;
+    }
+
+    /**
+     * Creates a new cache.
+     *
+     * @param options Cache options.
+     * @returns A new cache instance.
+     */
+    export function newCache(options: CacheOptions): Cache;
+}
+
+export {};

--- a/types/package.json
+++ b/types/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@enonic-types/lib-cache",
+  "version": "0.0.0",
+  "description": "Type definitions for the Enonic XP Cache library",
+  "types": "index.d.ts",
+  "files": [
+    "*"
+  ],
+  "keywords": [
+    "enonic",
+    "enonic-xp",
+    "lib-cache",
+    "cache",
+    "types",
+    "typescript"
+  ],
+  "license": "Apache-2.0",
+  "homepage": "https://github.com/enonic/lib-cache#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/enonic/lib-cache.git"
+  },
+  "bugs": {
+    "url": "https://github.com/enonic/lib-cache/issues"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@enonic-types/core": "^8.0.0"
+  }
+}


### PR DESCRIPTION
Publishes a TypeScript types package for lib-cache so consumers get typed access to the `/lib/cache` module instead of relying on hand-authored local declarations. Mirrors [lib-mustache#66](https://github.com/enonic/lib-mustache/pull/66).

## Module path

Consumers import from `/lib/cache` (the file lives at `src/main/resources/lib/cache.js`), so the types declare `module "/lib/cache"`.

## Exports typed (1:1 with cache.js + CacheBean.java)

- `newCache(options: CacheOptions): Cache`
- `interface CacheOptions { size?: number; expire?: number }`
- `interface Cache`:
  - `get<A>(key: string, callback: () => A): A`
  - `getIfPresent<A>(key: string): A | null`
  - `put(key: string, value: unknown): void`
  - `clear(): void`
  - `getSize(): number`
  - `remove(key: string): void`
  - `removePattern(keyRegex: string): void`

Signatures verified against `src/main/resources/lib/cache.js` and the underlying `CacheBean` / `CacheBeanBuilder` Java. `getIfPresent` returns `null` when the entry is missing (Guava semantics via `__.toNativeObject`).

## Changes

- `types/index.d.ts` — ambient `declare module "/lib/cache"` with the exports above.
- `types/package.json` — `@enonic-types/lib-cache` manifest; `publishConfig.access: public`; `@enonic-types/core: ^8.0.0` dep for the family convention.
- `build.gradle` — `assembleTypes` Copy task builds `build/types` with `project.version` substituted; `jar.dependsOn assembleTypes`.
- `.github/workflows/enonic-gradle.yml` — `npmPublish: true` on `build-and-publish` + top-level `permissions: { id-token: write, contents: write }` for npm OIDC / trusted publishing.

## Verified

- `./gradlew build` green.
- `build/types/` contains `index.d.ts` + `package.json` with `"version": "3.1.0-SNAPSHOT"` substituted.
- `.d.ts` type-checks under strict `tsc` (`moduleResolution: node`) with the standard XP `paths: { "/lib/cache": ["./node_modules/@enonic-types/lib-cache"] }` mapping; a negative check (`const bad: string = cache.getSize()`) is correctly rejected.

**Note:** the first publish of a brand-new `@enonic-types/lib-cache` may need npm trusted-publisher / package access configured org-side. Depends on [enonic/release-tools#71](https://github.com/enonic/release-tools/pull/71) — merged.

Closes #118

Generated with [Claude Code](https://claude.com/claude-code)