### PR TITLE
Align docs to standard layout #120

### DIFF
--- a/.github/workflows/enonic-docgen.yml
+++ b/.github/workflows/enonic-docgen.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - "master"
+      - "3.x"
       - "2.x"
     paths:
       - 'docs/**'

--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -1,5 +1,7 @@
 = Cache Library
 
+NOTE: Versions 3.x target XP 8+.
+
 This library is used for basic caching of resources in memory. It will automatically evict old
 entries when the cache is full. To start using this library, add the following dependency to your `build.gradle`
 file:
@@ -7,7 +9,7 @@ file:
 [source,groovy]
 ----
 dependencies {
-  include 'com.enonic.lib:lib-cache:2.2.0'
+  include "com.enonic.lib:lib-cache:${libVersion}"
 }
 ----
 
@@ -184,13 +186,3 @@ If the regex pattern does not match with any existing key, no changes are made.
 ----
 cache.removePattern('product.*');
 ----
-
-
-== Compatibility
-
-This library is also a drop-in replacement for the library in Enonic XP released before 6.11.0. It can be used directly since
-it will work by using `/lib/cache`, `/lib/xp/cache` and `/site/lib/xp/cache`.
-
-The `remove` and `removePattern` functions are only available since version *1.1.0*
-
-The `getIfPresent` and `put` functions are only available since version *2.2.0*

--- a/docs/versions.json
+++ b/docs/versions.json
@@ -1,6 +1,6 @@
 {
   "versions": [
-    { "label": "stable", "checkout": "2.x", "latest": true },
-    { "label": "next", "checkout": "master" }
+    { "label": "stable", "checkout": "3.x", "latest": true },
+    { "label": "2.x", "checkout": "2.x" }
   ]
 }


### PR DESCRIPTION
Aligns `lib-cache`'s documentation with the reference layout used by `enonic/lib-cors`, and removes version-history clutter so `docs/index.adoc` reads as documentation for the current version rather than a change log.

## Structure changes

- `docs/index.adoc`: added `NOTE: Versions 3.x target XP 8+.` near the top; changed the `build.gradle` example to use `${libVersion}` instead of a hard-coded (and outdated) `2.2.0`, matching the lib-cors example.
- `docs/versions.json`: switched to `stable=3.x` (latest) + `2.x`, matching gradle.properties layout (`master=3.1.0-SNAPSHOT`, `3.x=3.0.1-SNAPSHOT`, `2.x=2.2.2-SNAPSHOT`) and the lib-cors shape.
- `.github/workflows/enonic-docgen.yml`: added `3.x` to `on.push.branches` so the current stable branch also triggers docgen (was `master` + `2.x` only).

## Clutter removed from `docs/index.adoc`

The whole trailing `== Compatibility` section — all three lines were historical notes that no longer apply to the XP 8 line:

- "This library is also a drop-in replacement for the library in Enonic XP released before 6.11.0. It can be used directly since it will work by using `/lib/cache`, `/lib/xp/cache` and `/site/lib/xp/cache`." — XP 6 legacy; the XP-built-in cache module and its `/lib/xp/cache` / `/site/lib/xp/cache` paths do not exist in XP 8. The library ships `/lib/cache` only.
- "The `remove` and `removePattern` functions are only available since version *1.1.0*" — since-version note; applies to every currently-supported release.
- "The `getIfPresent` and `put` functions are only available since version *2.2.0*" — same.

## Kept

Nothing else in `docs/index.adoc` looked like version-history clutter — the `WARNING` about cache scope, the `IMPORTANT` about object references, and the `NOTE` on `Cache.put` are current, actionable caveats.

## Follow-up

The clutter-cleanup part will be cherry-picked to the `3.x` stable branch in a separate PR. The `2.x` (XP 7 legacy) branch is intentionally left untouched.

Closes #120