### PR TITLE
Align docs to standard layout (3.x) #120

### DIFF
--- a/.github/workflows/enonic-docgen.yml
+++ b/.github/workflows/enonic-docgen.yml
@@ -4,8 +4,8 @@ on:
   push:
     branches:
       - "master"
-      - "2.x"
       - "3.x"
+      - "2.x"
     paths:
       - 'docs/**'
   workflow_dispatch:

--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -1,5 +1,7 @@
 = Cache Library
 
+NOTE: Versions 3.x target XP 8+.
+
 This library is used for basic caching of resources in memory. It will automatically evict old
 entries when the cache is full. To start using this library, add the following dependency to your `build.gradle`
 file:
@@ -7,7 +9,7 @@ file:
 [source,groovy]
 ----
 dependencies {
-  include 'com.enonic.lib:lib-cache:2.2.0'
+  include "com.enonic.lib:lib-cache:${libVersion}"
 }
 ----
 
@@ -184,13 +186,3 @@ If the regex pattern does not match with any existing key, no changes are made.
 ----
 cache.removePattern('product.*');
 ----
-
-
-== Compatibility
-
-This library is also a drop-in replacement for the library in Enonic XP released before 6.11.0. It can be used directly since
-it will work by using `/lib/cache`, `/lib/xp/cache` and `/site/lib/xp/cache`.
-
-The `remove` and `removePattern` functions are only available since version *1.1.0*
-
-The `getIfPresent` and `put` functions are only available since version *2.2.0*

--- a/docs/versions.json
+++ b/docs/versions.json
@@ -1,6 +1,6 @@
 {
   "versions": [
-    { "label": "stable", "checkout": "2.x", "latest": true },
-    { "label": "next", "checkout": "master" }
+    { "label": "stable", "checkout": "3.x", "latest": true },
+    { "label": "2.x", "checkout": "2.x" }
   ]
 }


### PR DESCRIPTION
Cherry-pick of #121 (master) to the `3.x` stable branch.

## What's in this PR

- `docs/index.adoc`: added `NOTE: Versions 3.x target XP 8+.` near the top; switched the `build.gradle` example from a hard-coded `2.2.0` to `${libVersion}`; removed the whole `== Compatibility` section — three lines of legacy noise that no longer apply to the XP 8 line:
  - the pre-XP-8 6.11.0 drop-in-replacement note (references `/lib/xp/cache` / `/site/lib/xp/cache`, which don't exist under XP 8; the library ships `/lib/cache` only);
  - "The `remove` and `removePattern` functions are only available since version *1.1.0*";
  - "The `getIfPresent` and `put` functions are only available since version *2.2.0*".
- `docs/versions.json`: switched to `stable=3.x` (latest) + `2.x`, matching the reference lib-cors shape and this branch's actual role as the current stable.
- `.github/workflows/enonic-docgen.yml`: verified `on.push.branches` is `master / 3.x / 2.x` (this branch already had 3.x; the cherry-pick's auto-merge introduced a duplicate 3.x entry which was cleaned up in the amend).

## Related

- Primary PR (against `master`): #121
- Issue: #120
- The `2.x` (XP 7 legacy) branch is intentionally left untouched.