### PR TITLE
GraalJS Compatibility #124

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,8 +25,6 @@ dependencies {
     testImplementation libs.mockito.core
     testImplementation libs.mockito.jupiter
     testImplementation libs.assertj.core
-
-    testRuntimeOnly libs.graalvm.js
 }
 
 jacocoTestReport {
@@ -46,14 +44,6 @@ test {
     useJUnitPlatform()
 }
 
-def testGraalJs = tasks.register('testGraalJs', Test) {
-    group = 'verification'
-    description = 'Runs tests with the GraalJS script engine.'
-    useJUnitPlatform()
-    testClassesDirs = sourceSets.test.output.classesDirs
-    classpath = sourceSets.test.runtimeClasspath
-    systemProperty 'xp.script-engine', 'GraalJS'
-    shouldRunAfter test
+xp {
+    scriptEngines = ['Nashorn', 'GraalJS']
 }
-
-check.dependsOn testGraalJs

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,9 @@ repositories {
 
 dependencies {
     compileOnly xplibs.api.script
+    compileOnly "com.enonic.xp:core-api:${xpVersion}"
     testImplementation "com.enonic.xp:testing:${xpVersion}"
+    testImplementation libs.osgi.core
 
     testImplementation platform(libs.junit.bom)
     testImplementation libs.junit.jupiter
@@ -23,6 +25,8 @@ dependencies {
     testImplementation libs.mockito.core
     testImplementation libs.mockito.jupiter
     testImplementation libs.assertj.core
+
+    testRuntimeOnly libs.graalvm.js
 }
 
 jacocoTestReport {
@@ -41,3 +45,15 @@ artifacts {
 test {
     useJUnitPlatform()
 }
+
+def testGraalJs = tasks.register('testGraalJs', Test) {
+    group = 'verification'
+    description = 'Runs tests with the GraalJS script engine.'
+    useJUnitPlatform()
+    testClassesDirs = sourceSets.test.output.classesDirs
+    classpath = sourceSets.test.runtimeClasspath
+    systemProperty 'xp.script-engine', 'GraalJS'
+    shouldRunAfter test
+}
+
+check.dependsOn testGraalJs

--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -37,6 +37,40 @@ const cache = cacheLib.newCache({
 <1> Maximum number of items in the cache before it will evict the oldest.
 <2> Number of seconds the items will be in the cache before it's evicted.
 
+== Unnamed and named caches
+
+There are two kinds of cache, and giving a cache a `name` changes how its values are stored.
+
+*Unnamed* caches (no `name` option) live *per script context*. On a pooled engine the same `newCache`
+call at module level produces one cache in each context, so an entry stored in one context is not
+seen from another, `size` bounds *each* context's cache and `getSize()` reports only the calling
+context's entries. Values are cached *by reference* at no copy cost and any value can be stored. This
+is the original behaviour and is unchanged.
+
+*Named* caches (`name` option set) live *per application* and are shared by every context. The same
+name always returns the same cache; different names are different caches.
+
+[source,js]
+----
+const shared = cacheLib.newCache({
+    name:   'my-cache',   // <1>
+    size:   100,
+    expire: 3600
+});
+----
+<1> Makes the cache application-wide and shared across all contexts.
+
+IMPORTANT: Because a value in a named cache may outlive the context that produced it, values are
+stored as *data*: each `put` copies the value in and each `get`/`getIfPresent` copies it out. Mutating
+a retrieved value therefore never affects the cached entry, and functions, host objects and cyclic
+structures throw at `put` instead of being cached. Adding a `name` to a previously unnamed cache thus
+switches it from by-reference to copy semantics and may start throwing on a value that cached fine
+before.
+
+A named cache is cleared when its application is stopped, uninstalled or reconfigured. It is *not*
+cleared on a dev-mode script reload, and if `expire` is not set its entries live until one of those
+events occurs.
+
 From here on you can now use the cache functions on the cache. To get (or populate if not exists) items you can do like this:
 
 [source,js]
@@ -48,7 +82,7 @@ let item = cache.get('my-key', function() {     // <1>
 <1> Get function will either get the item if exists, or call the function to populate the cache.
 <2> Here you will do the actual population of the cache entry.
 
-IMPORTANT: *Object References and Immutability* - Objects stored in the cache are returned by reference, not by value. This means that if you modify a retrieved object, those modifications could affect the cached object itself. Deep clone the returned object after retrieval if the value must be changed.
+IMPORTANT: *Object References and Immutability* - In an *unnamed* cache, objects are returned by reference, not by value. This means that if you modify a retrieved object, those modifications could affect the cached object itself. Deep clone the returned object after retrieval if the value must be changed. A *named* cache instead stores a copy of the value, so mutating a retrieved object never affects the cached entry (see <<Unnamed and named caches>>).
 
 
 == API
@@ -62,6 +96,7 @@ This will create a new cache instance.
 *Parameters*
 
 * `config` (_object_) Configuration for the cache.
+** `name` (_string_) If set, creates an application-wide cache shared by all contexts under this name. See <<Unnamed and named caches>> — naming a cache changes its value semantics.
 ** `size` (_number_) Size of the cache (in number of items).
 ** `expire` (_number_)  If set, each item will be automatically purged from the cache after a set period, in seconds, has elapsed since the item's initial creation, or the most recent update of its value.
 
@@ -115,7 +150,7 @@ let item = cache.getIfPresent('my-key');
 
 This function will store the provided value for the named key in the cache, regardless if its previously set or not.
 
-NOTE: Cached objects are stored and retrieved by reference. Modifying an object after storing it, or modifying an object retrieved from the cache, could affect the cached value. Deep clone after retrieval if the value must be changed.
+NOTE: In an *unnamed* cache, objects are stored and retrieved by reference. Modifying an object after storing it, or modifying an object retrieved from the cache, could affect the cached value. Deep clone after retrieval if the value must be changed. In a *named* cache the value is copied as data on `put` (and again on `get`), so functions, host objects and cyclic structures throw here instead of being cached. See <<Unnamed and named caches>>.
 
 *Parameters*
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 group=com.enonic.lib
 projectName=lib-cache
-xpVersion=8.0.2
+xpVersion=8.1.0-SNAPSHOT
 version=3.1.0-SNAPSHOT

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,12 +4,10 @@ junit = "6.1.2"
 mockito = "5.23.0"
 assertj = "3.27.7"
 enonicDefaults = "2.1.7"
-graalvm = "25.0.3"
 osgi = "8.0.0"
 
 [libraries]
 
-graalvm-js = { module = "org.graalvm.polyglot:js", version.ref = "graalvm" }
 osgi-core = { module = "org.osgi:osgi.core", version.ref = "osgi" }
 
 junit-bom = { module = "org.junit:junit-bom", version.ref = "junit" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,8 +4,13 @@ junit = "6.1.2"
 mockito = "5.23.0"
 assertj = "3.27.7"
 enonicDefaults = "2.1.7"
+graalvm = "25.0.3"
+osgi = "8.0.0"
 
 [libraries]
+
+graalvm-js = { module = "org.graalvm.polyglot:js", version.ref = "graalvm" }
+osgi-core = { module = "org.osgi:osgi.core", version.ref = "osgi" }
 
 junit-bom = { module = "org.junit:junit-bom", version.ref = "junit" }
 junit-jupiter = { module = "org.junit.jupiter:junit-jupiter" }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'com.enonic.xp.settings' version '4.1.0'
+    id 'com.enonic.xp.settings' version '4.2.0'
 }
 
 rootProject.name = projectName

--- a/src/main/java/com/enonic/lib/cache/CacheRegistry.java
+++ b/src/main/java/com/enonic/lib/cache/CacheRegistry.java
@@ -1,0 +1,82 @@
+package com.enonic.lib.cache;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.TimeUnit;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceReference;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.util.tracker.ServiceTracker;
+import org.osgi.util.tracker.ServiceTrackerCustomizer;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+
+import com.enonic.xp.app.Application;
+import com.enonic.xp.app.ApplicationKey;
+
+@Component(immediate = true, service = CacheRegistry.class)
+public class CacheRegistry
+    implements ServiceTrackerCustomizer<Application, Application>
+{
+    private final ConcurrentMap<ApplicationKey, ConcurrentMap<String, Cache<String, Object>>> caches = new ConcurrentHashMap<>();
+
+    private final BundleContext context;
+
+    private final ServiceTracker<Application, Application> tracker;
+
+    @Activate
+    public CacheRegistry( final BundleContext context )
+    {
+        this.context = context;
+        this.tracker = new ServiceTracker<>( context, Application.class, this );
+        this.tracker.open();
+    }
+
+    @Deactivate
+    public void deactivate()
+    {
+        this.tracker.close();
+        this.caches.clear();
+    }
+
+    public Cache<String, Object> getOrCreate( final ApplicationKey app, final String name, final Integer size, final Integer expire )
+    {
+        return this.caches.computeIfAbsent( app, k -> new ConcurrentHashMap<>() ).computeIfAbsent( name, n -> build( size, expire ) );
+    }
+
+    private static Cache<String, Object> build( final Integer size, final Integer expire )
+    {
+        final CacheBuilder<Object, Object> builder = CacheBuilder.newBuilder();
+        if ( size != null )
+        {
+            builder.maximumSize( size );
+        }
+        if ( expire != null )
+        {
+            builder.expireAfterWrite( expire, TimeUnit.SECONDS );
+        }
+        return builder.build();
+    }
+
+    @Override
+    public Application addingService( final ServiceReference<Application> reference )
+    {
+        return this.context.getService( reference );
+    }
+
+    @Override
+    public void modifiedService( final ServiceReference<Application> reference, final Application application )
+    {
+    }
+
+    @Override
+    public void removedService( final ServiceReference<Application> reference, final Application application )
+    {
+        this.caches.remove( application.getKey() );
+        this.context.ungetService( reference );
+    }
+}

--- a/src/main/java/com/enonic/lib/cache/CacheValue.java
+++ b/src/main/java/com/enonic/lib/cache/CacheValue.java
@@ -1,0 +1,90 @@
+package com.enonic.lib.cache;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.enonic.xp.script.ScriptValue;
+import com.enonic.xp.script.serializer.MapGenerator;
+import com.enonic.xp.script.serializer.MapSerializable;
+
+final class CacheValue
+    implements MapSerializable
+{
+    private static final int MAX_DEPTH = 100;
+
+    private final Map<String, Object> value;
+
+    private CacheValue( final Map<String, Object> value )
+    {
+        this.value = value;
+    }
+
+    static Object toHostData( final ScriptValue value )
+    {
+        return convert( value, 0 );
+    }
+
+    private static Object convert( final ScriptValue value, final int depth )
+    {
+        if ( value == null )
+        {
+            return null;
+        }
+        if ( depth > MAX_DEPTH )
+        {
+            throw new IllegalArgumentException(
+                "Value cannot be stored in a named cache: the structure is cyclic or nested deeper than " + MAX_DEPTH + " levels" );
+        }
+        if ( value.isFunction() )
+        {
+            throw new IllegalArgumentException(
+                "Value cannot be stored in a named cache: functions are not data and cannot be shared between contexts" );
+        }
+        if ( value.isArray() )
+        {
+            final List<Object> list = new ArrayList<>();
+            for ( final ScriptValue element : value.getArray() )
+            {
+                list.add( convert( element, depth + 1 ) );
+            }
+            return list;
+        }
+        if ( value.isObject() )
+        {
+            final Map<String, Object> map = new LinkedHashMap<>();
+            for ( final String key : value.getKeys() )
+            {
+                map.put( key, convert( value.getMember( key ), depth + 1 ) );
+            }
+            return new CacheValue( map );
+        }
+        if ( value.isValue() )
+        {
+            return scalar( value.getValue() );
+        }
+        return null;
+    }
+
+    private static Object scalar( final Object raw )
+    {
+        if ( raw == null || raw instanceof String || raw instanceof Number || raw instanceof Boolean || raw instanceof Date )
+        {
+            return raw;
+        }
+        throw new IllegalArgumentException(
+            "Value cannot be stored in a named cache: values of type " + raw.getClass().getName() +
+                " are not data and cannot be shared between contexts" );
+    }
+
+    @Override
+    public void serialize( final MapGenerator gen )
+    {
+        for ( final Map.Entry<String, Object> entry : this.value.entrySet() )
+        {
+            gen.value( entry.getKey(), entry.getValue() );
+        }
+    }
+}

--- a/src/main/java/com/enonic/lib/cache/SharedCacheBean.java
+++ b/src/main/java/com/enonic/lib/cache/SharedCacheBean.java
@@ -1,0 +1,97 @@
+package com.enonic.lib.cache;
+
+import java.util.function.Supplier;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import com.google.common.cache.Cache;
+
+import com.enonic.xp.app.ApplicationKey;
+import com.enonic.xp.script.ScriptValue;
+import com.enonic.xp.script.bean.BeanContext;
+import com.enonic.xp.script.bean.ScriptBean;
+
+import static java.util.Objects.requireNonNull;
+
+public final class SharedCacheBean
+    implements ScriptBean
+{
+    private ApplicationKey applicationKey;
+
+    private Supplier<CacheRegistry> registry;
+
+    private String name;
+
+    private Integer size;
+
+    private Integer expire;
+
+    private Cache<String, Object> cache;
+
+    @Override
+    public void initialize( final BeanContext context )
+    {
+        this.applicationKey = context.getApplicationKey();
+        this.registry = context.getService( CacheRegistry.class );
+    }
+
+    public void setName( final String name )
+    {
+        this.name = name;
+    }
+
+    public void setSize( final int size )
+    {
+        this.size = size;
+    }
+
+    public void setExpire( final int expire )
+    {
+        this.expire = expire;
+    }
+
+    public void build()
+    {
+        this.cache = requireNonNull( this.registry.get() ).getOrCreate( this.applicationKey, this.name, this.size, this.expire );
+    }
+
+    public Object get( final String key, final ScriptValue callback )
+        throws Exception
+    {
+        return this.cache.get( key, () -> CacheValue.toHostData( callback.call() ) );
+    }
+
+    public Object getIfPresent( final String key )
+    {
+        return this.cache.getIfPresent( key );
+    }
+
+    public void put( final String key, final ScriptValue value )
+    {
+        this.cache.put( key, CacheValue.toHostData( value ) );
+    }
+
+    public void clear()
+    {
+        this.cache.invalidateAll();
+    }
+
+    public int getSize()
+    {
+        return (int) this.cache.size();
+    }
+
+    public void remove( final String key )
+    {
+        this.cache.invalidate( key );
+    }
+
+    public void removePattern( final String keyRegex )
+    {
+        final Pattern pattern = Pattern.compile( keyRegex );
+        final Stream<String> keyStream = this.cache.asMap().keySet().stream().filter( k -> pattern.matcher( k ).matches() );
+
+        final Iterable<String> keys = keyStream::iterator;
+        this.cache.invalidateAll( keys );
+    }
+}

--- a/src/main/resources/lib/cache.js
+++ b/src/main/resources/lib/cache.js
@@ -11,22 +11,29 @@
  * Creates a new cache with options.
  *
  * @param {*} native Native cache object.
+ * @param {boolean} shared True for an application-wide (named) cache, false for a per-context (unnamed) cache.
  * @constructor
  * @private
  */
-function Cache(native) {
+function Cache(native, shared) {
     this.cache = native;
+    this.shared = shared;
 }
 
 /**
  * Returns value for cache entry if exists, otherwise it's calculated and put into the cache.
+ *
+ * For a named (shared) cache the value returned by the callback is copied into the cache as data.
+ * See {@link module:cache.newCache} for the difference between named and unnamed caches.
  *
  * @param {string} key Cache key to use.
  * @param {function} callback Callback to a function that can calculate the cache value.
  * @returns {*} Cache value for key.
  */
 Cache.prototype.get = function (key, callback) {
-    var result = this.cache.get(key, callback);
+    var result = this.shared
+        ? this.cache.get(key, __.toScriptValue(callback))
+        : this.cache.get(key, callback);
     return __.toNativeObject(result);
 };
 
@@ -42,18 +49,28 @@ Cache.prototype.getIfPresent = function (key) {
 };
 
 /**
- * Puts the value into the cache with the provided key
+ * Puts the value into the cache with the provided key.
  *
- * **Important:** Objects are cached by reference. If you modify an object after storing it in the cache,
- * or modify an object retrieved from the cache, those modifications could affect the cached object.
- * Deep clone after retrieval if the value must be changed.
+ * **Important — the value contract depends on whether the cache is named** (see {@link module:cache.newCache}):
+ *
+ * - **Unnamed cache:** objects are cached *by reference*. If you modify an object after storing it,
+ *   or modify an object retrieved from the cache, those modifications could affect the cached object.
+ *   Deep clone after retrieval if the value must be changed. Any value can be cached.
+ * - **Named cache:** the value is *copied* as data on put (and again on get). Only data is accepted:
+ *   functions, host objects and cyclic structures throw an error here rather than being cached.
+ *   Adding a `name` to an existing cache therefore silently changes the semantics from by-reference
+ *   to copy, and may start throwing on a value that used to cache fine.
  *
  * @param {string} key Cache key to use.
  * @param {Object} value Value to store in the cache.
  */
-Cache.prototype.put = function (key, value){
-    this.cache.put(key, value);
-}
+Cache.prototype.put = function (key, value) {
+    if (this.shared) {
+        this.cache.put(key, __.toScriptValue(value));
+    } else {
+        this.cache.put(key, value);
+    }
+};
 
 /**
  * Clears the cache.
@@ -64,6 +81,8 @@ Cache.prototype.clear = function () {
 
 /**
  * Returns number of elements in cache.
+ *
+ * For an unnamed cache on a pooled engine this counts only the entries in the calling context's cache.
  *
  * @returns {number} Returns the number of elements that are currently in the cache.
  */
@@ -96,15 +115,52 @@ Cache.prototype.removePattern = function (keyRegex) {
 /**
  * Creates a new cache.
  *
+ * There are two kinds of cache, and **naming a cache changes its value semantics** — read this before
+ * adding a `name` to an existing cache:
+ *
+ * - **Unnamed** (no `name` option) — one cache *per script context*. On a pooled engine the same
+ *   `newCache` call at module level yields one cache in each context, so entries created in one
+ *   context miss in the others, `size` bounds *each* context's cache and `getSize()` counts only the
+ *   calling context's entries. Values are cached *by reference* at no copy cost, and any value can be
+ *   stored. This is the original behaviour and is unchanged.
+ * - **Named** (`name` option set) — one cache *per application*, shared by every context. The same
+ *   name returns the same cache; different names are different caches. Because a cached value may
+ *   outlive the context that produced it, values are stored as *data*: each `put` copies the value in
+ *   and each `get`/`getIfPresent` copies it out, so mutating a retrieved value never affects the
+ *   cached entry, and functions, host objects and cyclic structures throw at `put` instead of being
+ *   cached. Adding a `name` to a previously unnamed cache therefore switches it from by-reference to
+ *   copy semantics and may start throwing on a value that cached fine before.
+ *
+ * A named cache is cleared when its application is stopped, uninstalled or reconfigured. It is *not*
+ * cleared on a dev-mode script reload, and if `expire` is not set its entries live until one of those
+ * events occurs.
+ *
  * @example-ref examples/cache/newCache.js
  * @example-ref examples/cache/httpCache.js
  *
  * @param {object} options Cache options as JSON.
+ * @param {string} [options.name] If set, creates an application-wide cache shared by all contexts under this name (see above).
  * @param {number} options.size Maximum number of elements in the cache.
  * @param {number} options.expire Expire time (in sec) for cache entries. If not set, it will never expire.
  * @returns {Cache} Returns a new cache instance.
  */
 exports.newCache = function (options) {
+    if (options.name) {
+        const shared = __.newBean('com.enonic.lib.cache.SharedCacheBean');
+        shared.setName(options.name);
+
+        if (options.size) {
+            shared.setSize(options.size);
+        }
+
+        if (options.expire) {
+            shared.setExpire(options.expire);
+        }
+
+        shared.build();
+        return new Cache(shared, true);
+    }
+
     const builder = __.newBean('com.enonic.lib.cache.CacheBeanBuilder');
 
     if (options.size) {
@@ -116,5 +172,5 @@ exports.newCache = function (options) {
     }
 
     const cache = builder.build();
-    return new Cache(cache);
+    return new Cache(cache, false);
 };

--- a/src/test/java/com/enonic/lib/cache/CacheRegistryTest.java
+++ b/src/test/java/com/enonic/lib/cache/CacheRegistryTest.java
@@ -1,0 +1,74 @@
+package com.enonic.lib.cache;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.ServiceReference;
+
+import com.google.common.cache.Cache;
+
+import com.enonic.xp.app.Application;
+import com.enonic.xp.app.ApplicationKey;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.nullable;
+
+public class CacheRegistryTest
+{
+    private static final ApplicationKey APP = ApplicationKey.from( "myapp" );
+
+    private static BundleContext mockBundleContext()
+        throws Exception
+    {
+        final BundleContext context = Mockito.mock( BundleContext.class );
+        Mockito.when( context.createFilter( anyString() ) )
+            .thenAnswer( invocation -> FrameworkUtil.createFilter( invocation.getArgument( 0 ) ) );
+        Mockito.when( context.getServiceReferences( anyString(), nullable( String.class ) ) ).thenReturn( null );
+        return context;
+    }
+
+    @Test
+    public void sameNameReturnsSameCache()
+        throws Exception
+    {
+        final CacheRegistry registry = new CacheRegistry( mockBundleContext() );
+
+        final Cache<String, Object> first = registry.getOrCreate( APP, "x", 100, null );
+        final Cache<String, Object> second = registry.getOrCreate( APP, "x", 100, null );
+
+        assertThat( first ).isSameAs( second );
+    }
+
+    @Test
+    public void differentNamesReturnDifferentCaches()
+        throws Exception
+    {
+        final CacheRegistry registry = new CacheRegistry( mockBundleContext() );
+
+        assertThat( registry.getOrCreate( APP, "a", 100, null ) ).isNotSameAs( registry.getOrCreate( APP, "b", 100, null ) );
+    }
+
+    @Test
+    public void reregisteringApplicationClearsNamedCaches()
+        throws Exception
+    {
+        final CacheRegistry registry = new CacheRegistry( mockBundleContext() );
+
+        final Cache<String, Object> before = registry.getOrCreate( APP, "x", 100, null );
+        before.put( "k", "v" );
+        assertThat( before.getIfPresent( "k" ) ).isEqualTo( "v" );
+
+        final Application application = Mockito.mock( Application.class );
+        Mockito.when( application.getKey() ).thenReturn( APP );
+
+        @SuppressWarnings("unchecked") final ServiceReference<Application> reference = Mockito.mock( ServiceReference.class );
+
+        registry.removedService( reference, application );
+
+        final Cache<String, Object> after = registry.getOrCreate( APP, "x", 100, null );
+        assertThat( after ).isNotSameAs( before );
+        assertThat( after.getIfPresent( "k" ) ).isNull();
+    }
+}

--- a/src/test/java/com/enonic/lib/cache/CacheScriptTest.java
+++ b/src/test/java/com/enonic/lib/cache/CacheScriptTest.java
@@ -1,11 +1,16 @@
 package com.enonic.lib.cache;
-import java.beans.Transient;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+
 import com.enonic.xp.security.SecurityService;
 import com.enonic.xp.testing.ScriptTestSupport;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.nullable;
 
 public class CacheScriptTest
     extends ScriptTestSupport
@@ -19,6 +24,17 @@ public class CacheScriptTest
         super.initialize();
         this.securityService = Mockito.mock( SecurityService.class );
         addService( SecurityService.class, this.securityService );
+        addService( CacheRegistry.class, new CacheRegistry( mockBundleContext() ) );
+    }
+
+    private static BundleContext mockBundleContext()
+        throws Exception
+    {
+        final BundleContext context = Mockito.mock( BundleContext.class );
+        Mockito.when( context.createFilter( anyString() ) )
+            .thenAnswer( invocation -> FrameworkUtil.createFilter( invocation.getArgument( 0 ) ) );
+        Mockito.when( context.getServiceReferences( anyString(), nullable( String.class ) ) ).thenReturn( null );
+        return context;
     }
 
     @Test
@@ -44,10 +60,58 @@ public class CacheScriptTest
     {
         runFunction( "/test/cache-test.js", "testRemove" );
     }
-    
+
     @Test
     public void testRemovePattern()
     {
         runFunction( "/test/cache-test.js", "testRemovePattern" );
+    }
+
+    @Test
+    public void testNamedShareSameName()
+    {
+        runFunction( "/test/cache-test.js", "testNamedShareSameName" );
+    }
+
+    @Test
+    public void testNamedDifferentNamesIsolated()
+    {
+        runFunction( "/test/cache-test.js", "testNamedDifferentNamesIsolated" );
+    }
+
+    @Test
+    public void testUnnamedNotShared()
+    {
+        runFunction( "/test/cache-test.js", "testUnnamedNotShared" );
+    }
+
+    @Test
+    public void testNamedGetWithCallback()
+    {
+        runFunction( "/test/cache-test.js", "testNamedGetWithCallback" );
+    }
+
+    @Test
+    public void testNamedCopySemantics()
+    {
+        runFunction( "/test/cache-test.js", "testNamedCopySemantics" );
+    }
+
+    @Test
+    public void testUnnamedAcceptsAnyValue()
+    {
+        runFunction( "/test/cache-test.js", "testUnnamedAcceptsAnyValue" );
+    }
+
+    @Test
+    public void testNamedPutFunctionThrows()
+    {
+        runFunction( "/test/cache-test.js", "testNamedPutFunctionThrows" );
+    }
+
+    @Test
+    public void testNamedPutNestedFunctionThrows()
+    {
+        runFunction( "/test/cache-test.js", "testNamedPutNestedFunctionThrows" );
     }
 }

--- a/src/test/resources/test/cache-test.js
+++ b/src/test/resources/test/cache-test.js
@@ -122,3 +122,105 @@ exports.testRemovePattern = function () {
     cache.removePattern('key.*');
     assert.assertEquals(2, cache.getSize());
 };
+
+exports.testNamedShareSameName = function () {
+    var cache1 = cacheLib.newCache({ name: 'shared', size: 100 });
+    var cache2 = cacheLib.newCache({ name: 'shared', size: 100 });
+
+    cache1.put('key1', { num: 42, name: 'answer' });
+
+    var result = cache2.getIfPresent('key1');
+    assert.assertNotNull(result);
+    assert.assertEquals(42, result.num);
+    assert.assertEquals('answer', result.name);
+    assert.assertEquals(1, cache2.getSize());
+};
+
+exports.testNamedDifferentNamesIsolated = function () {
+    var cacheA = cacheLib.newCache({ name: 'a', size: 100 });
+    var cacheB = cacheLib.newCache({ name: 'b', size: 100 });
+
+    cacheA.put('key1', 'valueA');
+
+    assert.assertNull(cacheB.getIfPresent('key1'));
+    assert.assertEquals(0, cacheB.getSize());
+    assert.assertEquals('valueA', cacheA.getIfPresent('key1'));
+};
+
+exports.testUnnamedNotShared = function () {
+    var cache1 = cacheLib.newCache({ size: 100 });
+    var cache2 = cacheLib.newCache({ size: 100 });
+
+    cache1.put('key1', 'value1');
+
+    assert.assertNull(cache2.getIfPresent('key1'));
+    assert.assertEquals('value1', cache1.getIfPresent('key1'));
+};
+
+exports.testNamedGetWithCallback = function () {
+    var cache = cacheLib.newCache({ name: 'loader', size: 100 });
+
+    var numCalled = 0;
+    var calc = function () {
+        numCalled++;
+        return { num: numCalled, name: 'value' + numCalled };
+    };
+
+    var result = cache.get('key1', calc);
+    assert.assertEquals(1, result.num);
+    assert.assertEquals('value1', result.name);
+
+    result = cache.get('key1', calc);
+    assert.assertEquals(1, result.num);
+    assert.assertEquals(1, numCalled);
+    assert.assertEquals(1, cache.getSize());
+};
+
+exports.testNamedCopySemantics = function () {
+    var cache = cacheLib.newCache({ name: 'copy', size: 100 });
+
+    cache.put('key1', { num: 1, nested: { x: 1 }, list: [1, 2] });
+
+    var first = cache.getIfPresent('key1');
+    first.num = 999;
+    first.nested.x = 999;
+    first.list[0] = 999;
+
+    var second = cache.getIfPresent('key1');
+    assert.assertEquals(1, second.num);
+    assert.assertEquals(1, second.nested.x);
+    assert.assertEquals(1, second.list[0]);
+};
+
+exports.testUnnamedAcceptsAnyValue = function () {
+    var cache = cacheLib.newCache({ size: 100 });
+
+    cache.put('fn', function () {
+        return 42;
+    });
+    cache.put('obj', { num: 1 });
+
+    assert.assertEquals(2, cache.getSize());
+    assert.assertNotNull(cache.getIfPresent('fn'));
+    assert.assertEquals(1, cache.getIfPresent('obj').num);
+};
+
+exports.testNamedPutFunctionThrows = function () {
+    var cache = cacheLib.newCache({ name: 'fn', size: 100 });
+
+    assert.assertThrows(function () {
+        cache.put('key1', function () {
+            return 1;
+        });
+    });
+};
+
+exports.testNamedPutNestedFunctionThrows = function () {
+    var cache = cacheLib.newCache({ name: 'fn-nested', size: 100 });
+
+    assert.assertThrows(function () {
+        cache.put('key1', { callback: function () {
+            return 1;
+        } });
+    });
+};


### PR DESCRIPTION
Fixes #124

Adds **opt-in application-wide named caches** for the pooled GraalJS engine, following the OSGi registry pattern from enonic/lib-sql#154.

## ⚠️ Named caches have different value semantics from unnamed ones

This is a deliberate redesign, not a crash fix — lib-cache already works on GraalJS. Naming a cache **changes its value contract**, and a reviewer should read that divergence rather than discover it:

| | Unnamed (`newCache({size})`) | Named (`newCache({name, size})`) |
|---|---|---|
| Scope | one cache **per script context** (unchanged) | one cache **per application**, shared by all contexts |
| Values | stored **by reference**, no copy cost, anything cacheable | stored as **host data**, **copied on every put and get** |
| Non-data (functions, host objects, cyclic) | accepted as-is | **throw at `put`** |
| Cleared on app reconfigure/stop/uninstall | n/a (vanishes with the context) | yes |

**Why the divergence:** on a pooled engine a cached JS value belongs to the context that created it; sharing that reference across contexts re-enters (and can block on, or throw from) the owning context. A shared cache may therefore only ever hold host data — so named values are converted at the `ScriptValue` boundary and copied per put/get, and values that cannot be represented as data fail loudly at `put`. Unnamed caches never cross a context, so their values are untouched and their behaviour is exactly as before.

Adding a `name` to an existing cache thus silently switches it from reference to copy semantics and may start throwing on a value that cached fine before. This is documented prominently on `newCache` and on `put` (JSDoc + `docs/index.adoc`).

## What's included
- `CacheRegistry` — `@Component` holding `Map<ApplicationKey, Map<String, Cache>>`, cleared in `@Deactivate` and, crucially, in `removedService(...)` of a `ServiceTracker<Application>` (a reconfigure re-registers the Application without stopping the bundle, so `@Deactivate` alone would keep serving stale values). The JS-facing bean resolves the registry via `context.getService(CacheRegistry.class).get()`, so all contexts share one instance.
- `SharedCacheBean` + `CacheValue` — the named-cache bean and the boundary conversion (guest → host data; loader return value converted in the calling context; functions/host-objects/cyclic → `IllegalArgumentException`).
- `cache.js` / JSDoc / `docs/index.adoc` — two kinds documented; the existing "cached by reference" note is kept but qualified (by reference for unnamed, a copy for named); copy cost and per-context `size`/`getSize()` noted.
- Dual-engine tests (`test` + new `testGraalJs`), covering: same name shares / different names don't; cross-instance read; unnamed caches don't share; named copy semantics; unnamed accepts any value (unchanged contract); putting a function into a named cache throws; and a named cache cleared when its Application service is re-registered.

**Deliberately not done** (per the issue): named caches are *not* cleared on dev-mode reload, and `expire` is *not* made mandatory. Both are documented as accepted.

## Descriptor generation (verified)
The library jar contains **no** `OSGI-INF` descriptor — `-dsannotations` comes from the `com.enonic.xp.app` plugin, not `com.enonic.xp.base`, so bnd generates it only when an application embeds the library. Verified by building a throwaway app embedding `lib-cache`:
```
Service-Component: OSGI-INF/com.enonic.lib.cache.CacheRegistry.xml
<scr:component ... name="com.enonic.lib.cache.CacheRegistry" immediate="true" deactivate="deactivate" ...>
```

## Local verification
Built the platform branch `claude/graaljs-support-limitations-pzu6z8` to mavenLocal and ran with `--rerun-tasks`:
```
:test        17 tests, 0 failures   (Nashorn)
:testGraalJs 17 tests, 0 failures   (GraalJS)
```

## Draft — CI status
Marked **draft** as requested. This bumps `xpVersion` to `8.1.0-SNAPSHOT` (resolved from `repo.enonic.com/dev`).

CI **passed green on both engines** — the `Gradle Build` run executed `:test` (Nashorn) and `:testGraalJs` (GraalJS), then `:check`, ending `BUILD SUCCESSFUL`: https://github.com/enonic/lib-cache/actions/runs/30434464617

The new GraalJS-compat tests use `ScriptTestSupport` (not `ScriptRunnerSupport`), so they do not depend on the not-yet-published executor-lifecycle work and run green against the current dev snapshot. If a future dev `8.1.0-SNAPSHOT` regresses the `Callable`-handle / `ScriptRunnerSupport` behaviour this relies on (see enonic/xp#12198), `:testGraalJs` could go red until a fresh snapshot is published; verified locally against a mavenLocal platform build either way (`:test` and `:testGraalJs` — 17 tests, 0 failures each, `--rerun-tasks`).
